### PR TITLE
Add criterium to deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
  :deps {com.fingerhutpress.cljol_jvm_support/cljol_jvm_support {:mvn/version "1.0"}
         medley {:mvn/version "1.2.0"}
         ubergraph {:mvn/version "0.8.2"
-                   :exclusions [tailrecursion/cljs-priority-map]}}
+                   :exclusions [tailrecursion/cljs-priority-map]}
+        criterium {:mvn/version "0.4.5"}}
  :aliases
  {
   ;; Common alias to use for all Clojure/Java commands


### PR DESCRIPTION
Apparently, criterium needs to be in the classpath in order to use the `ubergraph-extras` namespace:

Exhibit A: https://github.com/jafingerhut/cljol/blob/master/src/clj/cljol/ubergraph_extras.clj#L7
Exhibit B: https://github.com/jafingerhut/cljol/blob/master/src/clj/cljol/performance.clj#L3